### PR TITLE
Made version detection prefer STDOUT.

### DIFF
--- a/lib/cliver.rb
+++ b/lib/cliver.rb
@@ -4,6 +4,7 @@ require File.expand_path('../core_ext/file', __FILE__)
 
 require 'cliver/version'
 require 'cliver/dependency'
+require 'cliver/shell_capture'
 require 'cliver/detector'
 require 'cliver/filter'
 

--- a/lib/cliver/detector.rb
+++ b/lib/cliver/detector.rb
@@ -40,15 +40,15 @@ module Cliver
     # @return [String] - should be contain {Gem::Version}-parsable
     #                    version number.
     def detect_version(executable_path)
-      output = shell_out_and_capture version_command(executable_path).shelljoin
-      if $?.exitstatus == 127
+      capture = ShellCapture.new(version_command(executable_path))
+      unless capture.command_found
         raise Cliver::Dependency::NotFound.new(
             "Could not find an executable at given path '#{executable_path}'." +
             "If this path was not specified explicitly, it is probably a " +
             "bug in [Cliver](https://github.com/yaauie/cliver/issues)."
           )
       end
-      output[version_pattern]
+      capture.stdout[version_pattern] || capture.stderr[version_pattern]
     end
 
     # This is the interface that any detector must have.
@@ -79,14 +79,6 @@ module Cliver
     # @return [Array<String>]
     def version_command(executable_path)
       [executable_path, *Array(command_arg)]
-    end
-
-    private
-
-    # @api private
-    # A boundary that is useful for testing.
-    def shell_out_and_capture(command)
-      `#{command} 2>&1`
     end
   end
 end

--- a/lib/cliver/shell_capture.rb
+++ b/lib/cliver/shell_capture.rb
@@ -1,0 +1,28 @@
+require 'open3'
+
+module Cliver
+  class ShellCapture
+    attr_reader :stdout, :stderr, :command_found
+
+    def initialize(command)
+      @stdout = @stderr = ''
+      begin
+        Open3.popen3(command) do |i, o, e|
+          @stdout = o.read.chomp
+          @stderr = e.read.chomp
+        end
+        # Fix for ruby 1.8.7 (and probably earlier):
+        # Open3.popen3 does not raise anything there, but the error goes to STDERR.
+        if @stderr =~ /open3.rb:\d+:in `exec': No such file or directory -.*\(Errno::ENOENT\)/ or
+           @stderr =~ /An exception occurred in a forked block\W+No such file or directory.*\(Errno::ENOENT\)/
+          @stderr = ''
+          @command_found = false
+        else
+          @command_found = true
+        end
+      rescue
+        @command_found = false
+      end
+    end
+  end
+end

--- a/spec/cliver/detector_spec.rb
+++ b/spec/cliver/detector_spec.rb
@@ -41,4 +41,38 @@ describe Cliver::Detector do
     its(:command_arg) { should eq [version_arg] }
     its(:version_pattern) { should eq regexp_arg }
   end
+
+  context 'detecting a command' do
+    before(:each) do
+      Cliver::ShellCapture.stub(:new => capture)
+    end
+
+    context 'that reports version on stdout' do
+      let(:capture) { double('capture', :stdout => '1.1',
+                                        :stderr => 'Warning: There is a monkey 1.2 metres left of you.',
+                                        :command_found => true) }
+
+      it 'should prefer the stdout output' do
+        expect(detector.detect_version('foo')).to eq('1.1')
+      end
+    end
+
+    context 'that reports version on stderr' do
+      let(:capture) { double('capture', :stdout => '',
+                                        :stderr => 'Version: 1.666',
+                                        :command_found => true) }
+
+      it 'should prefer the stderr output' do
+        expect(detector.detect_version('foo')).to eq('1.666')
+      end
+    end
+
+    context 'that does not exist' do
+      let(:capture) { Cliver::ShellCapture.new('acommandnosystemshouldhave123') }
+
+      it 'should raise an exception' do
+        expect { detector.detect_version('foo') }.to raise_error(Cliver::Dependency::NotFound)
+      end
+    end
+  end
 end

--- a/spec/cliver/shell_capture_spec.rb
+++ b/spec/cliver/shell_capture_spec.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+require 'cliver'
+
+describe Cliver::ShellCapture do
+  subject { Cliver::ShellCapture.new('./spec/support/test_command') }
+
+  its(:stdout) { should eq '1.1.1' }
+  its(:stderr) { should eq 'foo baar 1' }
+  its(:command_found) { should be_true }
+
+  context 'looking for a command that does not exist' do
+    subject { Cliver::ShellCapture.new('./spec/support/test_command_not_here') }
+
+    its(:stdout) { should eq '' }
+    its(:stderr) { should eq '' }
+    its(:command_found) { should be_false }
+  end
+end

--- a/spec/support/test_command
+++ b/spec/support/test_command
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+STDERR.puts 'foo baar 1'
+puts '1.1.1'


### PR DESCRIPTION
My shot at fixing issue #4.
Tried it on jruby 1.7.2 ((1.9.3p327) 2013-01-04 302c706 on OpenJDK 64-Bit Server VM 1.7.0_40-b31 +indy [linux-amd64]), it looked like Open3.popen3 worked there.
