### PR TITLE
skip directory.

### DIFF
--- a/lib/cliver/dependency.rb
+++ b/lib/cliver/dependency.rb
@@ -210,6 +210,7 @@ module Cliver
 
         next unless lookup_cache.add?(exe) # don't yield the same exe path 2x
         next unless File.executable?(exe)
+        next if File.directory?(exe)
 
         yield exe
       end

--- a/spec/cliver/dependency_spec.rb
+++ b/spec/cliver/dependency_spec.rb
@@ -1,0 +1,35 @@
+require 'cliver'
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+
+describe Cliver::Dependency do
+  let(:executable) { 'foo' }
+
+  before do
+    @paths = []
+
+    path = Dir.mktmpdir 'cliver'
+    FileUtils.mkdir path + '/foo'
+    @paths << path
+
+    path = Dir.mktmpdir 'cliver'
+    FileUtils.touch path + '/foo'
+    FileUtils.chmod 0755, path + '/foo'
+    @paths << path
+
+    @expect = path + '/foo'
+
+    @path = @paths.join File::PATH_SEPARATOR
+  end
+
+  after do
+    @paths.each do |tmpdir|
+      FileUtils.remove_entry_secure tmpdir
+    end
+  end
+
+  it 'should not detect directory' do
+    expect(Cliver::Dependency.new(executable, :path => @path).detect!).to eq @expect
+  end
+end


### PR DESCRIPTION
In most case, directory is executable. so, I thought need to check directory to prevent miss detection.
