### PR TITLE
Symlink detected as a exec

### DIFF
--- a/lib/cliver/dependency.rb
+++ b/lib/cliver/dependency.rb
@@ -209,7 +209,7 @@ module Cliver
         exe = File.absolute_path?(cmd) ? cmd : File.expand_path("#{cmd}#{ext}", path)
 
         next unless lookup_cache.add?(exe) # don't yield the same exe path 2x
-        next unless File.executable?(exe)
+        next unless File.executable?(exe) && !File.directory?(exe)
 
         yield exe
       end


### PR DESCRIPTION
With the following setup:

``` bash
> ls -la /opt/hello/bin
total 0
drwxr-xr-x  2 root  root   68 Aug 29 10:16 ./
drwxr-xr-x  4 root  root  136 Aug 29 10:16 ../
-rwxr-xr-x  1 root  root    0 Aug 29 10:17 hello
```

and

``` bash
lrwxrwxrwx 1 root root 28 Apr 16  2013 /usr/local/bin/hello -> /opt/hello
```

Cliver detects the symlink `/usr/local/bin/hello` as my `hello` exectuable

the relevant part of my `$PATH` is `/usr/local/bin/hello/bin:/usr/local/bin`
