### PR TITLE
Correct spacing for detect_version error message

### DIFF
--- a/lib/cliver/detector.rb
+++ b/lib/cliver/detector.rb
@@ -43,7 +43,7 @@ module Cliver
       capture = ShellCapture.new(version_command(executable_path))
       unless capture.command_found
         raise Cliver::Dependency::NotFound.new(
-            "Could not find an executable at given path '#{executable_path}'." +
+            "Could not find an executable at given path '#{executable_path}'. " +
             "If this path was not specified explicitly, it is probably a " +
             "bug in [Cliver](https://github.com/yaauie/cliver/issues)."
           )


### PR DESCRIPTION
- Noticed there are currently no tests for the contents of error messages so no test included here.
