### PR TITLE
Fix ruby warnings

### DIFF
--- a/cliver.gemspec
+++ b/cliver.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
-  spec.has_rdoc      = 'yard'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec',   '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~>1.2'

--- a/lib/cliver/dependency.rb
+++ b/lib/cliver/dependency.rb
@@ -56,7 +56,7 @@ module Cliver
       @strict = options.fetch(:strict, false)
 
       @executables = Array(executables).dup.freeze
-      @requirement = args unless args.empty?
+      @requirement = Array(args)
 
       check_compatibility!
     end
@@ -131,7 +131,7 @@ module Cliver
     # @param raw_version [String]
     # @return [Boolean]
     def requirement_satisfied_by?(raw_version)
-      return true unless @requirement
+      return true if @requirement.empty?
       parsable_version = @filter.apply(raw_version)[PARSABLE_GEM_VERSION]
       parsable_version || raise(ArgumentError) # TODO: make descriptive
       filtered_requirement.satisfied_by? Gem::Version.new(parsable_version)
@@ -185,7 +185,7 @@ module Cliver
     # @raise [ArgumentError] if version cannot be detected.
     def detect_version(executable_path)
       # No need to shell out if we are only checking its presence.
-      return '99.version_detection_not_required' unless @requirement
+      return '99.version_detection_not_required' if @requirement.empty?
 
       raw_version = @detector.to_proc.call(executable_path)
       raw_version || raise(ArgumentError,


### PR DESCRIPTION
I'm seeing a lot of warns like this:

```
/home/runner/work/ferrum/ferrum/vendor/bundle/ruby/2.6.0/gems/cliver-0.3.2/lib/cliver/dependency.rb:188: warning: instance variable @requirement not initialized
/home/runner/work/ferrum/ferrum/vendor/bundle/ruby/2.6.0/gems/cliver-0.3.2/lib/cliver/dependency.rb:134: warning: instance variable @requirement not initialized
```

I've bumped `bundler` and removed deprecated `has_rdoc`